### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
+[![Board Status](https://agomezjuan.visualstudio.com/0568c44d-f0c2-4775-a030-10e40bc12e3a/9b85275e-0c6a-40dc-8d2f-194096f422f5/_apis/work/boardbadge/b6c9e38c-a577-401f-8b56-6b88d3f84ea7)](https://agomezjuan.visualstudio.com/0568c44d-f0c2-4775-a030-10e40bc12e3a/_boards/board/t/9b85275e-0c6a-40dc-8d2f-194096f422f5/Microsoft.RequirementCategory)
 # ProyectoCiclo3-Grupo3


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://agomezjuan.visualstudio.com/0568c44d-f0c2-4775-a030-10e40bc12e3a/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.